### PR TITLE
Resolved future Symfony incompatibility announced via deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -13,9 +13,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $tree = new TreeBuilder();
-        $tree->root('intaro_postgres_search')
-            ->end();
+        $tree = new TreeBuilder('intaro_postgres_search');
+
+        // Keep compatibility with symfony/config < 4.2
+        if (!method_exists($tree, 'getRootNode')) {
+            $tree->root('intaro_postgres_search')->end();
+        } else {
+            $tree->getRootNode()->end();
+        }
 
         return $tree;
     }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add PostgreSearchBundle in your composer.json:
 ```js
 {
     "require": {
-        "intaro/postgres-search-bundle": "dev-master"
+        "shopsys/postgres-search-bundle": "0.1"
     }
 }
 ```
@@ -22,7 +22,7 @@ Add PostgreSearchBundle in your composer.json:
 Now tell composer to download the bundle by running the command:
 
 ``` bash
-$ php composer.phar update intaro/postgres-search-bundle
+$ php composer.phar update shopsys/postgres-search-bundle
 ```
 
 ### Step 2: Enable the bundle

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "intaro/postgres-search-bundle",
+    "name": "shopsys/postgres-search-bundle",
     "type": "symfony-bundle",
     "description": "Tools to use full-text search PostgreSQL in Doctrine.",
     "keywords": ["doctrine2", "symfony2", "search", "postgresql"],
@@ -17,7 +17,9 @@
         "doctrine/orm": ">=2.2.3"
     },
     "autoload": {
-        "psr-0": { "Intaro\\PostgresSearchBundle\\": "" }
+        "psr-0": {
+            "Intaro\\PostgresSearchBundle\\": ""
+        }
     },
     "target-dir": "Intaro/PostgresSearchBundle"
 }


### PR DESCRIPTION
Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future.